### PR TITLE
Pass raw Manifest data when creating new Tag

### DIFF
--- a/tag.js
+++ b/tag.js
@@ -37,13 +37,15 @@ async function main() {
         }
     );
 
-    /*const manifestData = await manifest.json.catch( async e => {
+    const manifestData = await manifest.blob.catch( async e => {
         core.setFailed(e.message);
         core.setFailed(await manifest.text);
-    });*/
+    });
+    /* Transform stream not available in Action (browser only)
+    Consider a Duplex Stream if Blob doesn't work
     const { readable, writable } = new TransformStream();
     
-    manifest.body.pipeTo(writable);
+    manifest.body.pipeTo(writable);*/
 
     const tagUrl = `https://${registry}/v2/${repository}/manifests/${newTag}`;
 
@@ -52,7 +54,7 @@ async function main() {
     const result = await requests.put(
         tagUrl,
         {
-            body: readable, //JSON.stringify(manifestData),
+            body: manifestData, //JSON.stringify(manifestData),
             headers: {
                 "Accept": mime,
                 "Content-Type": mime,

--- a/tag.js
+++ b/tag.js
@@ -14,9 +14,10 @@ async function main() {
     const repository = core.getInput("repository");
     const oldTag     = core.getInput("existing-tag");
     const newTag     = core.getInput("new-tag");
+    
 
     const auth = getAuth(registry);
-
+    
     core.debug("Registry:   " + registry);
     core.debug("Repositroy: " + repository);
     core.debug("Old Tag:    " + oldTag);
@@ -36,10 +37,13 @@ async function main() {
         }
     );
 
-    const manifestData = await manifest.json.catch( async e => {
+    /*const manifestData = await manifest.json.catch( async e => {
         core.setFailed(e.message);
         core.setFailed(await manifest.text);
-    });
+    });*/
+    const { readable, writable } = new TransformStream();
+    
+    manifest.body.pipeTo(writable);
 
     const tagUrl = `https://${registry}/v2/${repository}/manifests/${newTag}`;
 
@@ -48,7 +52,7 @@ async function main() {
     const result = await requests.put(
         tagUrl,
         {
-            body: JSON.stringify(manifestData),
+            body: readable, //JSON.stringify(manifestData),
             headers: {
                 "Accept": mime,
                 "Content-Type": mime,

--- a/tag.js
+++ b/tag.js
@@ -41,11 +41,6 @@ async function main() {
         core.setFailed(e.message);
         core.setFailed(await manifest.text);
     });
-    /* Transform stream not available in Action (browser only)
-    Consider a Duplex Stream if Blob doesn't work
-    const { readable, writable } = new TransformStream();
-    
-    manifest.body.pipeTo(writable);*/
 
     const tagUrl = `https://${registry}/v2/${repository}/manifests/${newTag}`;
 
@@ -54,7 +49,7 @@ async function main() {
     const result = await requests.put(
         tagUrl,
         {
-            body: manifestData, //JSON.stringify(manifestData),
+            body: manifestData,
             headers: {
                 "Accept": mime,
                 "Content-Type": mime,

--- a/tag.js
+++ b/tag.js
@@ -51,6 +51,7 @@ async function main() {
             body: JSON.stringify(manifestData),
             headers: {
                 "Accept": mime,
+                "Content-Type": mime,
                 "Authorization": auth
             },
         }
@@ -60,7 +61,7 @@ async function main() {
         core.debug("Successful");
         return;
     }
-
+    core.debug("Response Status: " + result.status + " " + result.statusText);
     core.debug(result);
 }
 


### PR DESCRIPTION
This PR changes behavior from sending a parsed JSON file to create new tags in remote Docker repos (specifically tested with Docker Hub) to passing the raw Blob content of the file.

Due to changes in whitespace content after parsing JSON, the destination image was not recognized as being identical to the one referenced by the incoming image tag, as discussed in #1.

This PR corrects that behavior and adds additional logging of response statuses when a PUT fails.